### PR TITLE
Fix cave biomes leaking into non-overworld dimensions' biome sources

### DIFF
--- a/src/main/java/com/farcr/nomansland/common/mixin/caves/MultiNoiseBiomeSourceMixin.java
+++ b/src/main/java/com/farcr/nomansland/common/mixin/caves/MultiNoiseBiomeSourceMixin.java
@@ -2,10 +2,12 @@ package com.farcr.nomansland.common.mixin.caves;
 
 import com.farcr.nomansland.common.registry.worldgen.NMLBiomes;
 import com.terraformersmc.biolith.impl.biome.BiomeCoordinator;
+import com.terraformersmc.biolith.impl.biome.InterfaceBiomeSource;
 import net.minecraft.core.Holder;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.biome.BiomeSource;
 import net.minecraft.world.level.biome.MultiNoiseBiomeSource;
+import net.minecraft.world.level.dimension.BuiltinDimensionTypes;
 import org.jetbrains.annotations.NotNull;
 import org.spongepowered.asm.mixin.Mixin;
 
@@ -18,10 +20,17 @@ public abstract class MultiNoiseBiomeSourceMixin extends BiomeSource {
     @Override
     public @NotNull Set<Holder<Biome>> possibleBiomes() {
         Set<Holder<Biome>> biomes = new HashSet<>(super.possibleBiomes());
-        BiomeCoordinator.getBiomeLookup().ifPresent(lookup ->
-                Stream.of(NMLBiomes.CAVES, NMLBiomes.CAVE_DEPTHS)
-                        .forEach(key -> lookup.get(key).ifPresent(biomes::add))
-        );
+        // The cave biomes are only ever placed in the overworld (see DimensionBiomePlacementMixin),
+        // so they must not be reported as possible biomes of other dimensions' sources. Mods like
+        // BetterNether merge the vanilla nether source's possible biomes into their own biome
+        // picker, which would make the cave biomes actually generate in the nether.
+        if (BuiltinDimensionTypes.OVERWORLD.location()
+                .equals(((InterfaceBiomeSource) (Object) this).biolith$getDimensionType().location())) {
+            BiomeCoordinator.getBiomeLookup().ifPresent(lookup ->
+                    Stream.of(NMLBiomes.CAVES, NMLBiomes.CAVE_DEPTHS)
+                            .forEach(key -> lookup.get(key).ifPresent(biomes::add))
+            );
+        }
         return biomes;
     }
 }


### PR DESCRIPTION
# Fix cave biomes leaking into non-overworld dimensions' biome sources

## The bug

`MultiNoiseBiomeSourceMixin#possibleBiomes` unconditionally adds `nomansland:caves` and `nomansland:cave_depths` to the possible-biome set of **every** `MultiNoiseBiomeSource`, regardless of which dimension the source belongs to — including the vanilla nether source inside the `minecraft:the_nether` level stem and modded dimensions like `deeperdarker:otherside`.

In a vanilla nether this is invisible (the biomes are never actually picked), but it breaks badly together with **BetterNether / WorldWeaver (wover)**: wover replaces the nether biome source with its own `WoverNetherBiomeSource` and *merges* the biomes of the source it replaces. Its `MergeableBiomeSource` logic force-adds every merged biome that isn't already in `#minecraft:is_nether` into that tag and into its nether biome picker. As a result **the two overworld cave biomes actually generate in the nether as full-fledged nether biomes**.

Since those biomes are in `#minecraft:has_structure/mineshaft`, `#minecraft:has_structure/trial_chambers`, `#minecraft:has_structure/ruined_portal_standard` and `#c:is_cave`, this drags mineshafts, trial chambers, ruined portals and any third-party structure sets targeting cave/underground tags into the nether. It also feeds overworld mob-spawn lists into nether chunk generation, which for some players escalates into worldgen-thread stalls/freezes (observed with Alex's Caves' `NaturalSpawner` chunk-generation spawning, e.g. striders with jockeys mounting during worldgen).

Log evidence from a pack with BetterNether (wover's world-dimensions report at world load), **before** the fix:

```
 - minecraft:the_nether:
     WoVer - Nether BiomeSource (50409aa6)
         biomes     = 29
         namespaces = betternether(22), minecraft(5), nomansland(2)
...
[wover-generator/]: Merged 2 biomes to WoVer - Nether BiomeSource (50409aa6) in 599.6 μs
```

The same two biomes also leak into `deeperdarker:otherside`:

```
     MultiNoiseBiomeSource (ac6381e)
         biomes     = 6
         namespaces = nomansland(2), deeperdarker(4)
```

This cannot be worked around by users: the mixin has no config gate, so disabling the cave biomes in the config does not stop the leak.

## The fix

Gate the injection on the biome source actually belonging to an overworld dimension, using the dimension type Biolith already tracks per biome source (`InterfaceBiomeSource#biolith$getDimensionType`) — the same check Biolith itself uses when deciding which placement's entries to inject. The cave biomes are only ever placed in the overworld (`DimensionBiomePlacementMixin` guards on `OverworldBiomePlacement`), so reporting them as possible biomes of other dimensions' sources is never correct.

## Testing

Tested on 1.21.1 / NeoForge with a ~230-mod pack including BetterNether 21.0.20, Deeper and Darker, TerraBlender and Biolith 3.0.12. After the fix:

- Nether source is clean: `biomes = 27, namespaces = betternether(22), minecraft(5)`; the `Merged 2 biomes` line is gone.
- `deeperdarker:otherside` is clean: `namespaces = deeperdarker(4)`.
- Overworld is unaffected: `namespaces = minecraft(53), spawn(10), nomansland(22), yungscavebiomes(2)` — same as before the fix, cave biomes still generate and decorate normally.
- No mixin errors in the log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
